### PR TITLE
coverage: Remove versioned entrypoints

### DIFF
--- a/recipes/coverage/bld.bat
+++ b/recipes/coverage/bld.bat
@@ -1,1 +1,16 @@
 %PYTHON% setup.py install --single-version-externally-managed --record record.txt
+
+:: Remove versioned entrypoints.
+%PYTHON% -c "import os; print('_'.join(os.environ['PY_VER'].split('.')[0]))" > temp.txt
+set /p PY_VER_MAJ=<temp.txt
+del temp.txt
+
+del %PREFIX%\Scripts\coverage%PY_VER_MAJ%-script.py
+del %PREFIX%\Scripts\coverage%PY_VER_MAJ%.exe
+del %PREFIX%\Scripts\coverage%PY_VER_MAJ%.exe.manifest
+
+del %PREFIX%\Scripts\coverage-%PY_VER%-script.py
+del %PREFIX%\Scripts\coverage-%PY_VER%.exe
+del %PREFIX%\Scripts\coverage-%PY_VER%.exe.manifest
+
+dir /s "%PREFIX%\Scripts\coverage*"

--- a/recipes/coverage/build.sh
+++ b/recipes/coverage/build.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
 
+
 $PYTHON setup.py install --single-version-externally-managed --record record.txt
+
+# Remove versioned entrypoints.
+PY_VER_MAJ=$($PYTHON -c "import os; print('_'.join(os.environ['PY_VER'].split('.')[0]))")
+
+rm "${PREFIX}/bin/coverage${PY_VER_MAJ}"
+rm "${PREFIX}/bin/coverage-${PY_VER}"
+
+ls $PREFIX/bin/coverage*

--- a/recipes/coverage/meta.yaml
+++ b/recipes/coverage/meta.yaml
@@ -19,6 +19,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - python
     - setuptools
   run:


### PR DESCRIPTION
Removes the versioned entrypoints to address reviewer comments. It's not pretty, but it works. Also lists the files afterwards to ensure there is nothing else lingering.